### PR TITLE
fix: stop deleting HTML output for zip-output networks

### DIFF
--- a/core/webpack.build.js
+++ b/core/webpack.build.js
@@ -234,9 +234,6 @@ function runBuild(webpackConfig, customOptions, customDefines, webpackCustomConf
 
     const compiler = webpack(webpackConfig);
 
-    // Check if ZipPlugin is used
-    const hasZipPlugin = webpackConfig.plugins?.some((plugin) => plugin instanceof ZipPlugin);
-
     compiler.run((err, stats) => {
       if (err) {
         console.error('Build failed:', err.stack || err);
@@ -251,14 +248,6 @@ function runBuild(webpackConfig, customOptions, customDefines, webpackCustomConf
         console.error(`Build finished with errors.`);
         reject(stats.compilation.errors);
       } else {
-        // Clean up temporary folder if ZipPlugin was used
-        if (hasZipPlugin && webpackConfig.output.path) {
-          try {
-            fs.rmSync(webpackConfig.output.path, { recursive: true, force: true });
-          } catch (cleanupErr) {
-            console.warn(`Warning: Could not clean up temporary folder:`, cleanupErr.message);
-          }
-        }
 
         console.log(`Build successful!`);
         resolve();


### PR DESCRIPTION
## Summary
- Removes the `fs.rmSync` cleanup of the temporary webpack output folder after ZipPlugin runs (added in v1.1.3)
- This cleanup deletes the HTML files that downstream build pipelines need to discover and upload per-network builds for google, mintegral, vungle, and other zip-output networks
- Without the HTML on disk, pipelines that scan `dist/` for `.html` files silently skip these networks

## Context
The ZipPlugin produces a `.zip` in the parent output directory, then the cleanup deletes the subfolder containing the source HTML. Build pipelines rely on finding those `.html` files to copy them into `SETT_TEST_HTML/` and include them in manifests. The cleanup breaks this for all zip-output networks.